### PR TITLE
messagesコントローラでメッセージを作成するアクションのテストをする

### DIFF
--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -34,4 +34,56 @@ describe MessagesController do
       end
     end
   end
+
+  describe '#create' do
+    let(:params) { { group_id: group.id, user_id: user.id, message: attributes_for(:message) } }
+
+    context 'log in' do
+      before do
+        login user
+      end
+
+      context 'can save' do
+        subject {
+          post :create,
+          params: params
+        }
+
+        it 'count up message' do
+          expect{ subject }.to change(Message, :count).by(1)
+        end
+
+        it 'redirects to group_messages_path' do
+          subject
+          expect(response).to redirect_to(group_messages_path(group))
+        end
+      end
+
+      context 'can not save' do
+        let(:invalid_params) { { group_id: group.id, user_id: user.id, message: attributes_for(:message, body: nil, image: nil) } }
+
+        subject{
+          post :create,
+          params: invalid_params
+        }
+
+        it 'dose not count up' do
+          expect{ subject }.not_to change(Message, :count)
+        end
+
+        it 'renders index' do
+          subject
+          expect(response).to render_template :index
+        end
+      end
+    end
+
+    context 'not log in' do
+
+      it 'redirects to new_user_session_path' do
+        post :create, params: params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# WHAT
messagesコントローラでメッセージを作成するアクションのテストをした。

# WHY
メッセージが作成できないと、チャット機能自体使用することができないため、messagesコントローラーのcreateアクションのテストを行った。