### PR TITLE
Capistranoの設定ファイルを編集

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -10,7 +10,7 @@ set :rbenv_type, :user
 set :rbenv_ruby, '2.3.1'
 
 set :ssh_options, auth_methods: ['publickey'],
-                  keys: ['/.ssh/key_pair.pem']
+                  keys: ['~/.ssh/key_pair.pem']
 
 set :unicorn_pid, -> { "#{shared_path}/tmp/pids/unicorn.pid" }
 set :unicorn_config_path, -> { "#{current_path}/config/unicorn.rb" }


### PR DESCRIPTION
# WHAT
Capistranoの設定ファイルを編集した。

# WHY
設定ファイルの記述が間違っていたことにより、自動デプロイ時にエラーが出たため。